### PR TITLE
Feat: mapID 구분하여 firebase storage 업로드

### DIFF
--- a/app/src/main/java/com/hsu/mapapp/map/MapIdViewModel.kt
+++ b/app/src/main/java/com/hsu/mapapp/map/MapIdViewModel.kt
@@ -1,0 +1,13 @@
+package com.hsu.mapapp.map
+
+import androidx.lifecycle.MutableLiveData
+
+import androidx.lifecycle.ViewModel
+
+
+class MapIdViewModel : ViewModel() {
+    val mapId = MutableLiveData<String>()
+    fun setMapId(id: String) {
+        mapId.value = id
+    }
+}

--- a/app/src/main/java/com/hsu/mapapp/map/MapItemList.kt
+++ b/app/src/main/java/com/hsu/mapapp/map/MapItemList.kt
@@ -6,5 +6,5 @@ data class MapItemList (
     val mapTitle: String = "",
     val previewImage: String = R.drawable.base_map.toString(),
     val mapSort: String = "korea",
-    val mapID: String = ""
+    val mapId: String = ""
         )

--- a/app/src/main/java/com/hsu/mapapp/map/MapViewModel.kt
+++ b/app/src/main/java/com/hsu/mapapp/map/MapViewModel.kt
@@ -29,7 +29,8 @@ class MapViewModel : ViewModel() {
                         MapItemList(
                             map["mapTitle"].toString(),
                             map["previewImage"].toString(),
-                            map["mapSort"].toString()
+                            map["mapSort"].toString(),
+                            map["mapId"].toString()
                         )
                     )
                 }

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -13,7 +13,6 @@
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragmentContainerView2"
-            android:name="com.hsu.mapapp.map.MapSeoulFragment"
             android:layout_width="423dp"
             android:layout_height="731dp"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
- 기존에 이미지뷰를 uid별로 폴더를 만들어 관리했지만 이제 mapID로 구분함.
- 지도 추가 시 mapID는 자동 생성
- firebase databse에 지도 리스트가 올라가고,
- firebase storage엔 이미지들이 올라감
- 지도 삭제도 잘 됨
- ++) 지도 삭제 시 storage 폴더 삭제 만들어야함.
- 지도 이름 변경은 아직 미완임 ㅜ

- color는 완성된건지 안된건지 몰라서 아직 손 안댐
- 처음 접속 시 시작 프래그먼트를 mapList의 0번째 map으로 하고싶은데 그렇게 설정하면 클릭이 안먹는 오류가 발생 ㅜ
- 그래서 처음엔 화면 비워져있고 목록에서 선택해야함

- 지도 삭제 다이얼로그도 띄워야할듯?

close #209
#210, #212 는 color까지 바꾸면 완성